### PR TITLE
Add limited OSX support

### DIFF
--- a/support/archi/simulator/simulator_pthread.h
+++ b/support/archi/simulator/simulator_pthread.h
@@ -23,7 +23,8 @@
   #define psleep(m_sec) Sleep ((m_sec))
 
 #elif defined (linux) || defined (LINUX) || defined (__linux__) \
-   || defined (unix) || defined (UNIX) || defined (__unix__)
+    || defined (unix) || defined (UNIX) || defined (__unix__) \
+    || defined (__APPLE__)
 
   #include <unistd.h>
   #define psleep(m_sec) usleep ((m_sec * 1000))

--- a/support/archi/simulator/simulator_socket.h
+++ b/support/archi/simulator/simulator_socket.h
@@ -19,7 +19,8 @@
     #define SOCKET_MODE 0
 
 #elif defined (linux) || defined (LINUX) || defined (__linux__) \
-   || defined (unix) || defined (UNIX) || defined (__unix__)
+   || defined (unix) || defined (UNIX) || defined (__unix__) \
+   || defined (__APPLE__)
 
     #include <sys/types.h>
     #include <sys/socket.h>


### PR DESCRIPTION
Hey!

I'm testing out this project for a board i'm designing (with a PIC32MK). One issue i had is with Apple/OSX support. 

This PR allows things to compile under OSX provided you have installed basic GNU support using `brew` : libpthread, GNU make, and GNU sed.

GNU sed is annoying under OSX because unfortunately the OS ships with BSD sed and they are incompatible... so I had to make sure that GNU sed is used first when invoking `sed`. 

Anyway this is just to allow building the simulator files with a Mac.
