### PR TITLE
Added a way to define custom board in my project

### DIFF
--- a/support/board/board.mk
+++ b/support/board/board.mk
@@ -1,6 +1,4 @@
 
-BOARDPATH = $(dir $(lastword $(MAKEFILE_LIST)))
-
 # check BOARD variable exists or DEVICE + ARCHI
 # BOARD does not have to be defined. A project can be setted BOARD (ie. working with a labdec) 
 ifndef BOARD
@@ -10,15 +8,21 @@ ifndef BOARD
 endif
 
 ifdef BOARD
- BOARD_FILE = $(UDEVKIT)/support/board/$(BOARD)/$(BOARD).mk
- 
- # check BOARD_FILE exists 
- ifeq ("$(wildcard $(BOARD_FILE))","")
-  $(error Invalid BOARD name)
- endif
- 
- # include the board file
- include $(BOARD_FILE)
- 
- INCLUDEPATH += -I$(UDEVKIT)/support/board/$(BOARD)/
+  BOARDPATH = $(dir $(lastword $(MAKEFILE_LIST)))
+  UDEV_BOARD_FILE = $(BOARDPATH)/$(BOARD)/$(BOARD).mk
+  OVERLAY_BOARD_FILE = ./support/board/$(BOARD)/$(BOARD).mk
+
+  ifeq ("$(wildcard $(OVERLAY_BOARD_FILE))","")
+    ifeq ("$(wildcard $(UDEV_BOARD_FILE))","")
+      $(error Invalid BOARD name $(BOARD))
+    else
+      # include the udevkit board file
+      include $(UDEV_BOARD_FILE)
+      INCLUDEPATH += -I$(UDEVKIT)/support/board/$(BOARD)/
+		endif
+  else
+    # include the overlay board file
+    include $(OVERLAY_BOARD_FILE)
+    INCLUDEPATH += -I./support/board/$(BOARD)/
+  endif
 endif


### PR DESCRIPTION
Hi

As a uDevKit user, I'd like want to be able to define a board inside my project, because
1) i don't know exactly what i'm doing yet
2) i'm not confortable sharing board definition details, etc

so this is a fairly crude attempt at having a `support/board/` local "overlay" directory where boards are searched first, then the uDev provided boards, then error out if not found.
